### PR TITLE
Fixed "UnsupportedOperationException" thrown when player joins

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,7 @@
 name: Build
-on: [ pull_request, push ]
+on: 
+  watch:
+    types: [started]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,5 @@
 name: Build
-on: 
-  watch:
-    types: [started]
+on: [ pull_request, push ]
 
 jobs:
   build:

--- a/fabric182/src/com/elikill58/negativity/fabric/FabricNegativity.java
+++ b/fabric182/src/com/elikill58/negativity/fabric/FabricNegativity.java
@@ -241,7 +241,8 @@ public class FabricNegativity implements DedicatedServerModInitializer {
 		@Override
 		public void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler,
 				PacketByteBuf buf, PacketSender responseSender) {
-			byte[] rawData = buf.readBytes(buf.capacity()).array();
+			byte[] rawData = new byte[buf.capacity()];
+			buf.readBytes(rawData);
 			HashMap<String, String> playerMods = NegativityPlayer.getNegativityPlayer(player.getUuid(),
 					() -> new FabricPlayer(player)).mods;
 			playerMods.clear();
@@ -254,7 +255,8 @@ public class FabricNegativity implements DedicatedServerModInitializer {
 		@Override
 		public void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler,
 				PacketByteBuf buf, PacketSender responseSender) {
-			byte[] rawData = buf.readBytes(buf.capacity()).array();
+			byte[] rawData = new byte[buf.capacity()];
+			buf.readBytes(rawData);
 			com.elikill58.negativity.api.events.EventManager
 					.callEvent(new GameChannelNegativityMessageEvent(FabricEntityManager.getPlayer(player), rawData));
 		}

--- a/fabric19/src/com/elikill58/negativity/fabric/FabricNegativity.java
+++ b/fabric19/src/com/elikill58/negativity/fabric/FabricNegativity.java
@@ -242,7 +242,8 @@ public class FabricNegativity implements DedicatedServerModInitializer {
 		@Override
 		public void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler,
 				PacketByteBuf buf, PacketSender responseSender) {
-			byte[] rawData = buf.readBytes(buf.capacity()).array();
+			byte[] rawData = new byte[buf.capacity()];
+			buf.readBytes(rawData);
 			HashMap<String, String> playerMods = NegativityPlayer.getNegativityPlayer(player.getUuid(),
 					() -> new FabricPlayer(player)).mods;
 			playerMods.clear();
@@ -255,7 +256,8 @@ public class FabricNegativity implements DedicatedServerModInitializer {
 		@Override
 		public void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler,
 				PacketByteBuf buf, PacketSender responseSender) {
-			byte[] rawData = buf.readBytes(buf.capacity()).array();
+			byte[] rawData = new byte[buf.capacity()];
+			buf.readBytes(rawData);
 			com.elikill58.negativity.api.events.EventManager
 					.callEvent(new GameChannelNegativityMessageEvent(FabricEntityManager.getPlayer(player), rawData));
 		}

--- a/fabric192/src/com/elikill58/negativity/fabric/FabricNegativity.java
+++ b/fabric192/src/com/elikill58/negativity/fabric/FabricNegativity.java
@@ -242,7 +242,8 @@ public class FabricNegativity implements DedicatedServerModInitializer {
 		@Override
 		public void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler,
 				PacketByteBuf buf, PacketSender responseSender) {
-			byte[] rawData = buf.readBytes(buf.capacity()).array();
+			byte[] rawData = new byte[buf.capacity()];
+			buf.readBytes(rawData);
 			HashMap<String, String> playerMods = NegativityPlayer.getNegativityPlayer(player.getUuid(),
 					() -> new FabricPlayer(player)).mods;
 			playerMods.clear();
@@ -255,7 +256,8 @@ public class FabricNegativity implements DedicatedServerModInitializer {
 		@Override
 		public void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler,
 				PacketByteBuf buf, PacketSender responseSender) {
-			byte[] rawData = buf.readBytes(buf.capacity()).array();
+			byte[] rawData = new byte[buf.capacity()];
+			buf.readBytes(rawData);
 			com.elikill58.negativity.api.events.EventManager
 					.callEvent(new GameChannelNegativityMessageEvent(FabricEntityManager.getPlayer(player), rawData));
 		}

--- a/fabric193/src/com/elikill58/negativity/fabric/FabricNegativity.java
+++ b/fabric193/src/com/elikill58/negativity/fabric/FabricNegativity.java
@@ -242,7 +242,8 @@ public class FabricNegativity implements DedicatedServerModInitializer {
 		@Override
 		public void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler,
 				PacketByteBuf buf, PacketSender responseSender) {
-			byte[] rawData = buf.readBytes(buf.capacity()).array();
+			byte[] rawData = new byte[buf.capacity()];
+			buf.readBytes(rawData);
 			HashMap<String, String> playerMods = NegativityPlayer.getNegativityPlayer(player.getUuid(),
 					() -> new FabricPlayer(player)).mods;
 			playerMods.clear();
@@ -255,7 +256,8 @@ public class FabricNegativity implements DedicatedServerModInitializer {
 		@Override
 		public void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler,
 				PacketByteBuf buf, PacketSender responseSender) {
-			byte[] rawData = buf.readBytes(buf.capacity()).array();
+			byte[] rawData = new byte[buf.capacity()];
+			buf.readBytes(rawData);
 			com.elikill58.negativity.api.events.EventManager
 					.callEvent(new GameChannelNegativityMessageEvent(FabricEntityManager.getPlayer(player), rawData));
 		}

--- a/fabric194/src/com/elikill58/negativity/fabric/FabricNegativity.java
+++ b/fabric194/src/com/elikill58/negativity/fabric/FabricNegativity.java
@@ -242,7 +242,8 @@ public class FabricNegativity implements DedicatedServerModInitializer {
 		@Override
 		public void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler,
 				PacketByteBuf buf, PacketSender responseSender) {
-			byte[] rawData = buf.readBytes(buf.capacity()).array();
+			byte[] rawData = new byte[buf.capacity()];
+			buf.readBytes(rawData)
 			HashMap<String, String> playerMods = NegativityPlayer.getNegativityPlayer(player.getUuid(),
 					() -> new FabricPlayer(player)).mods;
 			playerMods.clear();
@@ -255,7 +256,8 @@ public class FabricNegativity implements DedicatedServerModInitializer {
 		@Override
 		public void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler,
 				PacketByteBuf buf, PacketSender responseSender) {
-			byte[] rawData = buf.readBytes(buf.capacity()).array();
+			byte[] rawData = new byte[buf.capacity()];
+			buf.readBytes(rawData)
 			com.elikill58.negativity.api.events.EventManager
 					.callEvent(new GameChannelNegativityMessageEvent(FabricEntityManager.getPlayer(player), rawData));
 		}

--- a/fabric194/src/com/elikill58/negativity/fabric/FabricNegativity.java
+++ b/fabric194/src/com/elikill58/negativity/fabric/FabricNegativity.java
@@ -243,7 +243,7 @@ public class FabricNegativity implements DedicatedServerModInitializer {
 		public void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler,
 				PacketByteBuf buf, PacketSender responseSender) {
 			byte[] rawData = new byte[buf.capacity()];
-			buf.readBytes(rawData)
+			buf.readBytes(rawData);
 			HashMap<String, String> playerMods = NegativityPlayer.getNegativityPlayer(player.getUuid(),
 					() -> new FabricPlayer(player)).mods;
 			playerMods.clear();
@@ -257,7 +257,7 @@ public class FabricNegativity implements DedicatedServerModInitializer {
 		public void receive(MinecraftServer server, ServerPlayerEntity player, ServerPlayNetworkHandler handler,
 				PacketByteBuf buf, PacketSender responseSender) {
 			byte[] rawData = new byte[buf.capacity()];
-			buf.readBytes(rawData)
+			buf.readBytes(rawData);
 			com.elikill58.negativity.api.events.EventManager
 					.callEvent(new GameChannelNegativityMessageEvent(FabricEntityManager.getPlayer(player), rawData));
 		}


### PR DESCRIPTION
The netty update throws an "UnsupportedOperationException" error when a player joins (logs below)
```
[14:04:08] [Netty Epoll Play IO Thread #0/ERROR] (ServerPlayNetworkAddon for isWindChime) Encountered exception while handling in channel with name "negativity:msg"
java.lang.UnsupportedOperationException: direct buffer
        at io.netty.buffer.PooledUnsafeDirectByteBuf.array(PooledUnsafeDirectByteBuf.java:226) ~[netty-buffer-4.1.82.Final.jar:?]
        at com.elikill58.negativity.fabric.FabricNegativity$ProxyCompanionListener.receive(FabricNegativity.java:258) ~[NegativityFabric-19.4-1.2.0.jar:?]
        at net.fabricmc.fabric.impl.networking.server.ServerPlayNetworkAddon.receive(ServerPlayNetworkAddon.java:85) ~[fabric-networking-api-v1-1.3.4+10ce000ff4-1d544b9d5d8b2cf9.jar:?]
        at net.fabricmc.fabric.impl.networking.server.ServerPlayNetworkAddon.receive(ServerPlayNetworkAddon.java:39) ~[fabric-networking-api-v1-1.3.4+10ce000ff4-1d544b9d5d8b2cf9.jar:?]
        at net.fabricmc.fabric.impl.networking.AbstractChanneledNetworkAddon.handle(AbstractChanneledNetworkAddon.java:101) ~[fabric-networking-api-v1-1.3.4+10ce000ff4-1d544b9d5d8b2cf9.jar:?]
        at net.fabricmc.fabric.impl.networking.server.ServerPlayNetworkAddon.handle(ServerPlayNetworkAddon.java:80) ~[fabric-networking-api-v1-1.3.4+10ce000ff4-1d544b9d5d8b2cf9.jar:?]
        at net.minecraft.server.network.ServerPlayNetworkHandler.handler$zpg000$fabric-networking-api-v1$handleCustomPayloadReceivedAsync(ServerPlayNetworkHandler.java:2514) ~[server-intermediary.jar:?]
        at net.minecraft.server.network.ServerPlayNetworkHandler.onCustomPayload(ServerPlayNetworkHandler.java) ~[server-intermediary.jar:?]
        at net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket.apply(CustomPayloadC2SPacket.java:38) ~[server-intermediary.jar:?]
        at net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket.apply(CustomPayloadC2SPacket.java:7) ~[server-intermediary.jar:?]
        at net.minecraft.network.ClientConnection.handlePacket(ClientConnection.java:170) ~[server-intermediary.jar:?]
        at net.minecraft.network.ClientConnection.channelRead0(ClientConnection.java:155) ~[server-intermediary.jar:?]
        at net.minecraft.network.ClientConnection.channelRead0(ClientConnection.java:52) ~[server-intermediary.jar:?]
        at io.netty.channel.SimpleChannelInboundHandler.channelRead(SimpleChannelInboundHandler.java:99) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) ~[netty-codec-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:336) ~[netty-codec-4.1.82.Final.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:308) ~[netty-codec-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.handler.codec.MessageToMessageDecoder.channelRead(MessageToMessageDecoder.java:103) ~[netty-codec-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:336) ~[netty-codec-4.1.82.Final.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:308) ~[netty-codec-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:336) ~[netty-codec-4.1.82.Final.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.fireChannelRead(ByteToMessageDecoder.java:323) ~[netty-codec-4.1.82.Final.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.callDecode(ByteToMessageDecoder.java:444) ~[netty-codec-4.1.82.Final.jar:?]
        at io.netty.handler.codec.ByteToMessageDecoder.channelRead(ByteToMessageDecoder.java:280) ~[netty-codec-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.handler.timeout.IdleStateHandler.channelRead(IdleStateHandler.java:286) ~[netty-handler-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.fireChannelRead(AbstractChannelHandlerContext.java:357) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.DefaultChannelPipeline$HeadContext.channelRead(DefaultChannelPipeline.java:1410) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:379) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:365) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.DefaultChannelPipeline.fireChannelRead(DefaultChannelPipeline.java:919) ~[netty-transport-4.1.82.Final.jar:?]
        at io.netty.channel.epoll.AbstractEpollStreamChannel$EpollStreamUnsafe.epollInReady(AbstractEpollStreamChannel.java:800) ~[netty-transport-classes-epoll-4.1.82.Final.jar:?]
        at io.netty.channel.epoll.EpollEventLoop.processReady(EpollEventLoop.java:499) ~[netty-transport-classes-epoll-4.1.82.Final.jar:?]
        at io.netty.channel.epoll.EpollEventLoop.run(EpollEventLoop.java:397) ~[netty-transport-classes-epoll-4.1.82.Final.jar:?]
        at io.netty.util.concurrent.SingleThreadEventExecutor$4.run(SingleThreadEventExecutor.java:997) ~[netty-common-4.1.82.Final.jar:?]
        at io.netty.util.internal.ThreadExecutorMap$2.run(ThreadExecutorMap.java:74) ~[netty-common-4.1.82.Final.jar:?]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.82.Final.jar:?]
        at java.lang.Thread.run(Thread.java:1623) ~[?:?]
[14:04:08] [Server thread/WARN] (negativity) [Negativity] Please, don't use reload, this can produce some problem. Currently, isWindChime isn't fully checked because of that. More details: decoder (NoSuchElementException).Trying again ...
[14:04:09] [Server thread/INFO] (Minecraft) isWindChime joined the game
[14:04:09] [Server thread/INFO] (Minecraft) isWindChime lost connection: Internal Exception: java.lang.UnsupportedOperationException: direct buffer
[14:04:09] [Server thread/INFO] (Minecraft) isWindChime left the game
```
This pr fixes that problem